### PR TITLE
(#60) - Adiciona doc de planejamento

### DIFF
--- a/docs/planejamento.md
+++ b/docs/planejamento.md
@@ -1,0 +1,39 @@
+# Planejamento
+
+| Data | Atividade |
+| -- | --|
+| 28/03/2023 | Inicio do projeto |
+| 03/04/2023 | [Semana 01](Relatórios/semana1.md) |
+| 03/04/2023 | Reunião de Kick-off com o cliente |
+| 10/04/2023 | [Semana 02](Relatórios/semana2.md) |
+| 13/04/2023 | Treinamento de Git + Docker|
+| 17/04/2023 | Semana 03 |
+| 18/04/2023 | Treinamento de Git|
+| 24/04/2023 | Semana 04 |
+| 01/05/2023 | Semana 05 |
+| 09/05/2023 | Sprint 01 |
+| 09/05/2023 | Treinamento Front-end|
+| 13/05/2023 | Treinamento Front-end|
+| 16/05/2023 | Sprint 02 |
+| 22/05/2023 | Entrega de release ao cliente |
+| 23/05/2023 | Sprint 03 |
+| 30/05/2023 | Sprint 04 |
+| 06/06/2023 | Sprint 05 |
+| 13/06/2023 | Sprint 06 |
+| 20/06/2023 | Sprint 07 |
+| 27/06/2023 | Sprint 08 |
+| 04/07/2023 | Sprint 09 |
+| 10/07/2023 | Entrega de release ao cliente |
+| 11/07/2023 | Sprint 10 |
+| 18/07/2023 | Sprint 11 |
+| 25/07/2023 | Sprint 12 |
+
+
+## Histórico de versão
+
+| Data | Versão | Descrição | Autor(es) |
+| ---- | ------ | --------- | --------- |
+| 14/05/2023 | 1.0 | Criação do documento | Artur Jackson, Oscar de Brito |
+
+## Referência
+> ALDÍSIO, Antônio. PLANEJAMENTO. Disponível em: [link](https://fga-eps-mds.github.io/2022-2-CAPJu-Doc/#/pages/planning). Acesso em: 06 de maio de 2023.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,3 +20,4 @@ nav:
         - Quadro de pareamento: Controle/quadro_de_pareamento.md
         - Cronograma de dojo: Controle/cronograma_de_dojo.md
         - Plano de gerenciamento de riscos: plano_de_gerenciamento_de_riscos.md
+    - Planejamento: planejamento.md


### PR DESCRIPTION
## Issue
Determina a criação de documento de planejamento.

Closes fga-eps-mds/2023-1-CAPJu-Doc#60

## Descrição

Adiciona documento de planejamento.

## Revisão 

- [ ] Documentar datas importantes para o grupo.
- [ ] Documentar os dados das semanas pré-projeto e planejar as datas das sprints futuras.
- [ ] Integrar o documento ao arquivo do mkdocs.

## Pre-merge checklist 

- [ ] O Pull Request refere-se a um único assunto, um título claro e uma descrição em frases gramaticalmente corretas e completas.
- [ ] A ramificação está atualizada com a branch Develop.
- [ ] Os commits atendem o padrão especificado na política de contribuição.


