### PR TITLE
Modificar a página inicial da documentação

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,12 +4,12 @@
 
 CAPJu é a sigla para "Controle e Acompanhamento de Processos da Justiça", um projeto de código aberto com o propósito de auxiliar os usuários de diversas Varas da Justiça Federal na gestão de processos legais.
 
-Este repositório contém exclusivamente a documentação do projeto, a qual é predominantemente em Português do Brasil, visando atender aos interesses do público-alvo.
+Este repositório contém exclusivamente a documentação do projeto, a qual é predominantemente em português do Brasil, visando atender aos interesses do público-alvo.
 
 O CAPJu é uma aplicação web compatível com todos os navegadores.
+<br/><br/>
 
-
-# Integrantes do time
+## Integrantes do time
 
 ## MDS
 | Foto                                                                         | Nome                                | Matrícula | GitHub                                               |
@@ -24,7 +24,7 @@ O CAPJu é uma aplicação web compatível com todos os navegadores.
 | <img src="https://avatars.githubusercontent.com/u/90487905?v=4    " width="100"> | Leandro de Almeida    | 211030827 | [@leomitx10](https://github.com/leomitx10)       |
 | <img src="https://avatars.githubusercontent.com/u/98489703?v=4" width="100"> | Oscar de Brito                     | 211031790 | [@OscarDeBrito](https://github.com/OscarDeBrito) 
 | <img src="https://avatars.githubusercontent.com/u/83103936?v=4" width="100"> | Yan Werlley             | 211030649 | [@YanWerlley](https://github.com/YanWerlley) |
-
+<br/><br/>
 ## EPS
 | Foto                                                                         | Nome                                | Matrícula | GitHub                                               |
 | ---------------------------------------------------------------------------- | ----------------------------------- | --------- | ---------------------------------------------------- |

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,8 @@ O CAPJu é uma aplicação web compatível com todos os navegadores.
 ## Integrantes do time
 
 ## MDS
+<br/>
+
 | Foto                                                                         | Nome                                | Matrícula | GitHub                                               |
 | ---------------------------------------------------------------------------- | ----------------------------------- | --------- | ---------------------------------------------------- |
 | <img src="https://avatars.githubusercontent.com/u/122410504?v=4" width="100"> | Ana Karoliny                | 211031575 | [@AnaKarolinyCavalcanti](https://github.com/AnaKarolinyCavalcanti)                 |
@@ -33,6 +35,20 @@ O CAPJu é uma aplicação web compatível com todos os navegadores.
 | <img src="https://avatars.githubusercontent.com/u/52058094?v=4" width="100"> | Victor Samuel            | 180028685 | [@victordsantoss](https://github.com/victordsantoss)   |
 | <img src="https://avatars.githubusercontent.com/u/49957412?v=4" width="100"> | Vinícius Vieira           | 170115500 | [@faco400](https://github.com/faco400)   |
 | <img src="https://avatars.githubusercontent.com/u/217238?v=4" width="100"> | Wellington Jonathan             | 190048760 | [@wellpriz](https://github.com/wellpriz)   |
+
+
+
+
+## Repositórios
+
+- [Documentação](https://github.com/fga-eps-mds/2023-1-CAPJu-Doc)
+- [Services](https://github.com/fga-eps-mds/2023-1-CAPJu-Services)
+-  [Front-end](https://github.com/fga-eps-mds/2023-1-CAPJu-Front)
+- [User](https://github.com/fga-eps-mds/2023-1-CAPJu-User)
+
+<br/><br/>
+
+
 
 
 ### Histórico de versão

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,12 +9,12 @@ Este repositório contém exclusivamente a documentação do projeto, a qual é 
 O CAPJu é uma aplicação web compatível com todos os navegadores.
 
 
-## Integrantes do grupo
+# Integrantes do time
 
+## MDS
 | Foto                                                                         | Nome                                | Matrícula | GitHub                                               |
 | ---------------------------------------------------------------------------- | ----------------------------------- | --------- | ---------------------------------------------------- |
 | <img src="https://avatars.githubusercontent.com/u/122410504?v=4" width="100"> | Ana Karoliny                | 211031575 | [@AnaKarolinyCavalcanti](https://github.com/AnaKarolinyCavalcanti)                 |
-| <img src="https://avatars.githubusercontent.com/u/49957403?v=4" width="100"> | Arthur Sena             | 180030345 | [@senaarth](https://github.com/senaarth)   |
 | <img src="https://avatars.githubusercontent.com/u/100738244?v=4" width="100"> | Artur Jackson                   | 211030943 | [@artur-jack](https://github.com/artur-jack)           |
 | <img src="https://avatars.githubusercontent.com/u/91036264?v=4" width="100"> | Flávio Gustavo| 211030602 | [@flavioovatsug](https://github.com/flavioovatsug)     |
 | <img src="https://avatars.githubusercontent.com/u/92813703?v=4" width="100"> | Guilherme de Sá    | 211031056 | [@GuilhermeDSa1013](https://github.com/GuilhermeDSa1013)             |
@@ -22,14 +22,19 @@ O CAPJu é uma aplicação web compatível com todos os navegadores.
 | <img src="https://avatars.githubusercontent.com/u/129622482?v=4" width="100"> | Harryson Campos               | 211039466 | [@harry-cmartin ](https://github.com/harry-cmartin)                 |
 | <img src="https://avatars.githubusercontent.com/u/96394878?v=4" width="100"> | Juan Pablo              | 211041043 | [@Juan-Ricarte](https://github.com/Juan-Ricarte)           |
 | <img src="https://avatars.githubusercontent.com/u/90487905?v=4    " width="100"> | Leandro de Almeida    | 211030827 | [@leomitx10](https://github.com/leomitx10)       |
-| <img src="https://avatars.githubusercontent.com/u/98489703?v=4" width="100"> | Oscar de Brito                     | 211031790 | [@OscarDeBrito](https://github.com/OscarDeBrito) |
+| <img src="https://avatars.githubusercontent.com/u/98489703?v=4" width="100"> | Oscar de Brito                     | 211031790 | [@OscarDeBrito](https://github.com/OscarDeBrito) 
+| <img src="https://avatars.githubusercontent.com/u/83103936?v=4" width="100"> | Yan Werlley             | 211030649 | [@YanWerlley](https://github.com/YanWerlley) |
+
+## EPS
+| Foto                                                                         | Nome                                | Matrícula | GitHub                                               |
+| ---------------------------------------------------------------------------- | ----------------------------------- | --------- | ---------------------------------------------------- |
+<img src="https://avatars.githubusercontent.com/u/49957403?v=4" width="100"> | Arthur Sena             | 180030345 | [@senaarth](https://github.com/senaarth)   |
 | <img src="https://avatars.githubusercontent.com/u/78034696?v=4" width="100"> | Peniel  Zannoukou           | 180011308 | [zpeniel09](https://github.com/zpeniel09)   |
 | <img src="https://avatars.githubusercontent.com/u/48688714?v=4" width="100"> | Rodrigo Lima            | 180037242 | [@RodrigoTCLima](https://github.com/RodrigoTCLima)   |
 | <img src="https://avatars.githubusercontent.com/u/36544528?v=4" width="100"> | Sérgio de Almeida       | 180037439 | [@sergiosacj](https://github.com/sergiosacj)   |
 | <img src="https://avatars.githubusercontent.com/u/52058094?v=4" width="100"> | Victor Samuel            | 180028685 | [@victordsantoss](https://github.com/victordsantoss)   |
 | <img src="https://avatars.githubusercontent.com/u/49957412?v=4" width="100"> | Vinícius Vieira           | 170115500 | [@faco400](https://github.com/faco400)   |
 | <img src="https://avatars.githubusercontent.com/u/217238?v=4" width="100"> | Wellington Jonathan             | 190048760 | [@wellpriz](https://github.com/wellpriz)   |
-| <img src="https://avatars.githubusercontent.com/u/83103936?v=4" width="100"> | Yan Werlley             | 211030649 | [@YanWerlley](https://github.com/YanWerlley)   |
 
 ### Histórico de versão
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,38 @@
-# Welcome to MkDocs
+# CAPJu
 
-For full documentation visit [mkdocs.org](https://www.mkdocs.org).
+## Sobre o projeto
 
-## Commands
+CAPJu é a sigla para "Controle e Acompanhamento de Processos da Justiça", um projeto de código aberto com o propósito de auxiliar os usuários de diversas Varas da Justiça Federal na gestão de processos legais.
 
-* `mkdocs new [dir-name]` - Create a new project.
-* `mkdocs serve` - Start the live-reloading docs server.
-* `mkdocs build` - Build the documentation site.
-* `mkdocs -h` - Print help message and exit.
+Este repositório contém exclusivamente a documentação do projeto, a qual é predominantemente em Português do Brasil, visando atender aos interesses do público-alvo.
 
-## Project layout
+O CAPJu é uma aplicação web compatível com todos os navegadores.
 
-    mkdocs.yml    # The configuration file.
-    docs/
-        index.md  # The documentation homepage.
-        ...       # Other markdown pages, images and other files.
+
+## Integrantes do grupo
+
+| Foto                                                                         | Nome                                | Matrícula | GitHub                                               |
+| ---------------------------------------------------------------------------- | ----------------------------------- | --------- | ---------------------------------------------------- |
+| <img src="https://avatars.githubusercontent.com/u/122410504?v=4" width="100"> | Ana Karoliny                | 211031575 | [@AnaKarolinyCavalcanti](https://github.com/AnaKarolinyCavalcanti)                 |
+| <img src="https://avatars.githubusercontent.com/u/49957403?v=4" width="100"> | Arthur Sena             | 180030345 | [@senaarth](https://github.com/senaarth)   |
+| <img src="https://avatars.githubusercontent.com/u/100738244?v=4" width="100"> | Artur Jackson                   | 211030943 | [@artur-jack](https://github.com/artur-jack)           |
+| <img src="https://avatars.githubusercontent.com/u/91036264?v=4" width="100"> | Flávio Gustavo| 211030602 | [@flavioovatsug](https://github.com/flavioovatsug)     |
+| <img src="https://avatars.githubusercontent.com/u/92813703?v=4" width="100"> | Guilherme de Sá    | 211031056 | [@GuilhermeDSa1013](https://github.com/GuilhermeDSa1013)             |
+| <img src="https://avatars.githubusercontent.com/u/61592832?v=4" width="100"> | Gustavo França       | 211030774 | [@gustavofbs](https://github.com/gustavofbs)           |
+| <img src="https://avatars.githubusercontent.com/u/129622482?v=4" width="100"> | Harryson Campos               | 211039466 | [@harry-cmartin ](https://github.com/harry-cmartin)                 |
+| <img src="https://avatars.githubusercontent.com/u/96394878?v=4" width="100"> | Juan Pablo              | 211041043 | [@Juan-Ricarte](https://github.com/Juan-Ricarte)           |
+| <img src="https://avatars.githubusercontent.com/u/90487905?v=4    " width="100"> | Leandro de Almeida    | 211030827 | [@leomitx10](https://github.com/leomitx10)       |
+| <img src="https://avatars.githubusercontent.com/u/98489703?v=4" width="100"> | Oscar de Brito                     | 211031790 | [@OscarDeBrito](https://github.com/OscarDeBrito) |
+| <img src="https://avatars.githubusercontent.com/u/78034696?v=4" width="100"> | Peniel  Zannoukou           | 180011308 | [zpeniel09](https://github.com/zpeniel09)   |
+| <img src="https://avatars.githubusercontent.com/u/48688714?v=4" width="100"> | Rodrigo Lima            | 180037242 | [@RodrigoTCLima](https://github.com/RodrigoTCLima)   |
+| <img src="https://avatars.githubusercontent.com/u/36544528?v=4" width="100"> | Sérgio de Almeida       | 180037439 | [@sergiosacj](https://github.com/sergiosacj)   |
+| <img src="https://avatars.githubusercontent.com/u/52058094?v=4" width="100"> | Victor Samuel            | 180028685 | [@victordsantoss](https://github.com/victordsantoss)   |
+| <img src="https://avatars.githubusercontent.com/u/49957412?v=4" width="100"> | Vinícius Vieira           | 170115500 | [@faco400](https://github.com/faco400)   |
+| <img src="https://avatars.githubusercontent.com/u/217238?v=4" width="100"> | Wellington Jonathan             | 190048760 | [@wellpriz](https://github.com/wellpriz)   |
+| <img src="https://avatars.githubusercontent.com/u/83103936?v=4" width="100"> | Yan Werlley             | 211030649 | [@YanWerlley](https://github.com/YanWerlley)   |
+
+### Histórico de versão
+
+| Versão | Data       | Modificação          | Autor |
+| ------ | ---------- | -------------------- | -----|
+| 1.0    | 15/05/2023 | Criação do Documento | Oscar de Brito, Artur Jackson |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,4 @@
-# CAPJu
-
-## Sobre o projeto
+<img src="https://capju.netlify.app/logo.png" width="150">
 
 CAPJu é a sigla para "Controle e Acompanhamento de Processos da Justiça", um projeto de código aberto com o propósito de auxiliar os usuários de diversas Varas da Justiça Federal na gestão de processos legais.
 
@@ -24,7 +22,7 @@ O CAPJu é uma aplicação web compatível com todos os navegadores.
 | <img src="https://avatars.githubusercontent.com/u/90487905?v=4    " width="100"> | Leandro de Almeida    | 211030827 | [@leomitx10](https://github.com/leomitx10)       |
 | <img src="https://avatars.githubusercontent.com/u/98489703?v=4" width="100"> | Oscar de Brito                     | 211031790 | [@OscarDeBrito](https://github.com/OscarDeBrito) 
 | <img src="https://avatars.githubusercontent.com/u/83103936?v=4" width="100"> | Yan Werlley             | 211030649 | [@YanWerlley](https://github.com/YanWerlley) |
-<br/><br/>
+
 ## EPS
 | Foto                                                                         | Nome                                | Matrícula | GitHub                                               |
 | ---------------------------------------------------------------------------- | ----------------------------------- | --------- | ---------------------------------------------------- |
@@ -35,6 +33,7 @@ O CAPJu é uma aplicação web compatível com todos os navegadores.
 | <img src="https://avatars.githubusercontent.com/u/52058094?v=4" width="100"> | Victor Samuel            | 180028685 | [@victordsantoss](https://github.com/victordsantoss)   |
 | <img src="https://avatars.githubusercontent.com/u/49957412?v=4" width="100"> | Vinícius Vieira           | 170115500 | [@faco400](https://github.com/faco400)   |
 | <img src="https://avatars.githubusercontent.com/u/217238?v=4" width="100"> | Wellington Jonathan             | 190048760 | [@wellpriz](https://github.com/wellpriz)   |
+
 
 ### Histórico de versão
 


### PR DESCRIPTION
## Issue
Atualmente a página inical da documentação do github pages é a padrão do MKdocs, portanto é necessário modficá-la para apresentação do projeto e de seus integrantes.

Closes fga-eps-mds/2023-1-CAPJu-Doc#125

## Descrição
 Modifiquei a página inicial da documentação para apresentar a descrição do projeto e seus contribuidores.

## Revisão 

- [x]  Descrever o projeto 
- [x]  Descrever a equipe

## Pre-merge checklist 

- [x] O Pull Request refere-se a um único assunto, um título claro e uma descrição em frases gramaticalmente corretas e completas.
- [ ] A ramificação está atualizada com a branch Develop.
- [x] Os commits atendem o padrão especificado na política de contribuição.