### PR TITLE
apaga segundo planejamento do mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,5 @@ nav:
         - Plano de gerenciamento de riscos: plano_de_gerenciamento_de_riscos.md
         - Comunicação do time: comunicacao.md
         - Ferramentas utilizadas pela equipe: ferramentas_utilizadas_pela_equipe.md
-    - Planejamento: planejamento.md
 
 


### PR DESCRIPTION
## Issue

Closes fga-eps-mds/2023-1-CAPJu-Doc#179

## Descrição

Apagar segundo "Planejamento" do mkdocs.yml, pois está repetido

## Revisão 
<!-- Verifica se os critérios estabelecidos na issue foram realizados -->
- [ ] Ter apenas um "Planejamento" no mkdocs.yml

## Pre-merge checklist 

- [ ] O Pull Request refere-se a um único assunto, um título claro e uma descrição em frases gramaticalmente corretas e completas.
- [ ] A ramificação está atualizada com a branch Develop.
- [ ] Os commits atendem o padrão especificado na política de contribuição.
